### PR TITLE
Added support for Iterable, Iterator and Mapping

### DIFF
--- a/src/tests/test_annotate.py
+++ b/src/tests/test_annotate.py
@@ -13,7 +13,7 @@ from pyoload import type_match
 from pyoload import unannotable
 from pyoload import unannotate
 
-assert pyoload.__version__ == "2.0.1"
+assert pyoload.__version__ == "2.0.2"
 
 
 @annotate

--- a/src/tests/test_cast.py
+++ b/src/tests/test_cast.py
@@ -9,7 +9,7 @@ from pyoload import Union
 from pyoload import annotate
 from pyoload import type_match
 
-assert pyoload.__version__ == "2.0.1"
+assert pyoload.__version__ == "2.0.2"
 
 
 @annotate

--- a/src/tests/test_check.py
+++ b/src/tests/test_check.py
@@ -7,7 +7,7 @@ from pyoload import Checks
 from pyoload import Check
 from pyoload import annotate
 
-assert pyoload.__version__ == "2.0.1"
+assert pyoload.__version__ == "2.0.2"
 
 
 @annotate

--- a/src/tests/test_errors.py
+++ b/src/tests/test_errors.py
@@ -1,7 +1,7 @@
 import pyoload
 
 
-assert pyoload.__version__ == "2.0.1"
+assert pyoload.__version__ == "2.0.2"
 
 
 errors = (

--- a/src/tests/test_overload.py
+++ b/src/tests/test_overload.py
@@ -5,7 +5,7 @@ from pyoload import OverloadError
 from pyoload import get_name
 from pyoload import overload
 
-assert pyoload.__version__ == "2.0.1"
+assert pyoload.__version__ == "2.0.2"
 
 
 @overload

--- a/src/tests/test_values.py
+++ b/src/tests/test_values.py
@@ -4,7 +4,7 @@ from pyoload import AnnotationError
 import pyoload
 
 
-assert pyoload.__version__ == "2.0.1"
+assert pyoload.__version__ == "2.0.2"
 
 
 @annotate


### PR DESCRIPTION
Custumized type_match() to be able to check for builtin Iterable, Iterator and Mapping as if were normal datatypes. we can now do `Iterable[int]`